### PR TITLE
Apply ethereum/go-ethereum#17728 to secp256k1.h

### DIFF
--- a/crypto/secp256k1/libsecp256k1/src/secp256k1.h
+++ b/crypto/secp256k1/libsecp256k1/src/secp256k1.h
@@ -26,7 +26,6 @@
 } while(0)
 
 static void default_illegal_callback_fn(const char* str, void* data) {
-    (void)data;
     fprintf(stderr, "[libsecp256k1] illegal argument: %s\n", str);
     abort();
 }
@@ -37,7 +36,6 @@ static const secp256k1_callback default_illegal_callback = {
 };
 
 static void default_error_callback_fn(const char* str, void* data) {
-    (void)data;
     fprintf(stderr, "[libsecp256k1] internal consistency check failed: %s\n", str);
     abort();
 }


### PR DESCRIPTION
When building on Windows (as a dependency of building https://github.com/prysmaticlabs/prysm) linking will fail in the way described in ethereum/go-ethereum#17728, i.e. `undefined reference to __getreent` linker errors. The fix for this is simple: remove `(void)data;` in `default_illegal_callback_fn` and `default_error_callback_fn`. This was done in secp256k1.c, but the bazel-go-ethereum fork has the the two affected functions redefined in `secp256k1.h`, which upstream does not have. This PR simply applies the fix to the header file as well. After making this change the prysm beacon-chain builds on Windows with `go build .\beacon-chain`.