### PR TITLE
Fix proto conflicts

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/ethereum/go-ethereum
-# gazelle:proto disable_global
 gazelle(
     name = "gazelle",
     prefix = "github.com/ethereum/go-ethereum",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,35 +1,46 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "207fad3e6689135c5d8713e5a17ba9d1290238f47b9ba545b63d9303406209c6",
+    sha256 = "7c10271940c6bce577d51a075ae77728964db285dac0a46614a7934dc34303e6",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.7/rules_go-v0.24.7.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.7/rules_go-v0.24.7.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "1f4fc1d91826ec436ae04833430626f4cc02c20bb0a813c0c2f3c4c421307b1d",
-    strip_prefix = "bazel-gazelle-e368a11b76e92932122d824970dc0ce5feb9c349",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
     urls = [
-        "https://github.com/bazelbuild/bazel-gazelle/archive/e368a11b76e92932122d824970dc0ce5feb9c349.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
     ],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(version = "1.16")
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
+
+git_repository(
+    name = "com_google_protobuf",
+    commit = "fde7cf7358ec7cd69e8db9be4f1fa6a5c431386a",  # v3.13.0
+    remote = "https://github.com/protocolbuffers/protobuf",
+    shallow_since = "1597443653 -0700",
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 load("//:deps.bzl", "geth_dependencies")
 
 # gazelle:repository_macro deps.bzl%geth_dependencies
 geth_dependencies()
-

--- a/accounts/usbwallet/trezor/BUILD.bazel
+++ b/accounts/usbwallet/trezor/BUILD.bazel
@@ -13,6 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
     ],
 )

--- a/crypto/BUILD.bazel
+++ b/crypto/BUILD.bazel
@@ -50,9 +50,6 @@ go_library(
             "//crypto/secp256k1:go_default_library",
             "@com_github_btcsuite_btcd//btcec:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@com_github_btcsuite_btcd//btcec:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//crypto/secp256k1:go_default_library",
             "@com_github_btcsuite_btcd//btcec:go_default_library",

--- a/crypto/bn256/BUILD.bazel
+++ b/crypto/bn256/BUILD.bazel
@@ -15,9 +15,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:amd64": [
             "//crypto/bn256/cloudflare:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:amd64p32": [
-            "//crypto/bn256/google:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:arm": [
             "//crypto/bn256/google:go_default_library",
         ],

--- a/ethdb/leveldb/BUILD.bazel
+++ b/ethdb/leveldb/BUILD.bazel
@@ -94,17 +94,6 @@ go_library(
             "@com_github_syndtr_goleveldb//leveldb/opt:go_default_library",
             "@com_github_syndtr_goleveldb//leveldb/util:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//common:go_default_library",
-            "//ethdb:go_default_library",
-            "//log:go_default_library",
-            "//metrics:go_default_library",
-            "@com_github_syndtr_goleveldb//leveldb:go_default_library",
-            "@com_github_syndtr_goleveldb//leveldb/errors:go_default_library",
-            "@com_github_syndtr_goleveldb//leveldb/filter:go_default_library",
-            "@com_github_syndtr_goleveldb//leveldb/opt:go_default_library",
-            "@com_github_syndtr_goleveldb//leveldb/util:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//common:go_default_library",
             "//ethdb:go_default_library",

--- a/metrics/BUILD.bazel
+++ b/metrics/BUILD.bazel
@@ -66,9 +66,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "@com_github_shirou_gopsutil//cpu:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@com_github_shirou_gopsutil//cpu:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@com_github_shirou_gopsutil//cpu:go_default_library",
         ],


### PR DESCRIPTION
See https://github.com/prysmaticlabs/ethereumapis/pull/231 and https://github.com/prysmaticlabs/ethereumapis/pull/232.

This removes a proto conflict issue.

The problem is that this repo should use the wkt target to prevent the underlying library from being included twice.

![deps](https://user-images.githubusercontent.com/7246818/110835408-5d625d00-8264-11eb-8dff-fd391e41c044.png)

Some gazelle changes as well in BUILD files.